### PR TITLE
Make the aspect_ratio parameter consistent with documentation and the commonly expected behaviour 

### DIFF
--- a/examples/example.ipynb
+++ b/examples/example.ipynb
@@ -2,7 +2,7 @@
  "cells": [
   {
    "cell_type": "code",
-   "execution_count": 1,
+   "execution_count": 2,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -23,6 +23,7 @@
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -31,7 +32,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 2,
+   "execution_count": 3,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -39,6 +40,7 @@
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -47,7 +49,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 3,
+   "execution_count": 4,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -68,6 +70,7 @@
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -76,7 +79,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 4,
+   "execution_count": 5,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -127,7 +130,7 @@
     "dummy_data[3] = scipy.ndimage.uniform_filter(dummy_data[0], size=9, mode='wrap')\n",
     "\n",
     "# The actual plotting\n",
-    "fig = formatter.figure(aspect_ratio=0.28, wide=True)\n",
+    "fig = formatter.figure(aspect_ratio=3.57, wide=True)\n",
     "    \n",
     "ax1 = plt.subplot2grid((1,17), (0,0), colspan=4)\n",
     "ax2 = plt.subplot2grid((1,17), (0,4), colspan=4)\n",
@@ -151,6 +154,7 @@
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -161,7 +165,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 5,
+   "execution_count": 7,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -173,7 +177,7 @@
     "x = rs.gamma(2, size=1000)\n",
     "y = -.5 * x + rs.normal(size=1000)\n",
     "\n",
-    "sns.jointplot(x, y, kind=\"hex\", color=\"#4CB391\")\n",
+    "sns.jointplot(x=x, y=y, kind=\"hex\", color=\"#4CB391\")\n",
     "\n",
     "plt.tight_layout()\n",
     "plt.savefig(\"hexbin.pdf\")"
@@ -203,7 +207,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.7.5-final"
+   "version": "3.11.2"
   }
  },
  "nbformat": 4,

--- a/rsmf/abstract_formatter.py
+++ b/rsmf/abstract_formatter.py
@@ -87,7 +87,7 @@ class AbstractFormatter(abc.ABC):
         plt.rcParams["legend.framealpha"] = 1.0
         plt.rcParams["legend.fancybox"] = False
 
-    def figure(self, aspect_ratio=1 / 1.62, width_ratio=1.0, wide=False):
+    def figure(self, aspect_ratio=1.62, width_ratio=1.0, wide=False):
         r"""Sets up the plot with the fitting arguments so that the font sizes of the plot
         and the font sizes of the document are well aligned.
 
@@ -112,6 +112,6 @@ class AbstractFormatter(abc.ABC):
         base_width = self.wide_columnwidth if wide else self.columnwidth
 
         width = base_width * width_ratio
-        height = width * aspect_ratio
+        height = width / aspect_ratio
 
         return plt.figure(figsize=(width, height), dpi=120, facecolor="white")

--- a/tests/test_abstract_formatter.py
+++ b/tests/test_abstract_formatter.py
@@ -68,7 +68,7 @@ class TestFigure:
             ),
             (
                 {"columnwidth": 1.0, "wide_columnwidth": 2.0},
-                {"aspect_ratio": 0.5, "width_ratio": 1.0, "wide": True},
+                {"aspect_ratio": 2.0, "width_ratio": 1.0, "wide": True},
                 (2.0, 1.0),
             ),
             (
@@ -78,7 +78,7 @@ class TestFigure:
             ),
             (
                 {"columnwidth": 0.5, "wide_columnwidth": 2.0},
-                {"aspect_ratio": 2.0, "width_ratio": 1.0, "wide": False},
+                {"aspect_ratio": 0.5, "width_ratio": 1.0, "wide": False},
                 (0.5, 1.0),
             ),
         ],

--- a/tests/test_custom_formatter.py
+++ b/tests/test_custom_formatter.py
@@ -66,7 +66,7 @@ class TestFigure:
             ),
             (
                 {"wide_columnwidth": 2.0, "fontsizes": 11},
-                {"aspect_ratio": 0.5, "width_ratio": 1.0, "wide": True},
+                {"aspect_ratio": 2.0, "width_ratio": 1.0, "wide": True},
                 (2.0, 1.0),
             ),
             (
@@ -76,7 +76,7 @@ class TestFigure:
             ),
             (
                 {"columnwidth": 0.5, "wide_columnwidth": 2.0, "fontsizes": 11},
-                {"aspect_ratio": 2.0, "width_ratio": 1.0, "wide": False},
+                {"aspect_ratio": 0.5, "width_ratio": 1.0, "wide": False},
                 (0.5, 1.0),
             ),
         ],

--- a/tests/test_quantumarticle.py
+++ b/tests/test_quantumarticle.py
@@ -100,7 +100,7 @@ class TestFigure:
             ),
             (
                 {"columns": "twocolumn", "paper": "letterpaper", "fontsize": 11},
-                {"aspect_ratio": 1.4, "width_ratio": 1.0, "wide": False},
+                {"aspect_ratio": 0.71428, "width_ratio": 1.0, "wide": False},
                 (3.34, 4.676),
             ),
             (
@@ -110,17 +110,17 @@ class TestFigure:
             ),
             (
                 {"columns": "twocolumn", "paper": "letterpaper", "fontsize": 11},
-                {"aspect_ratio": 2.0, "width_ratio": 0.6, "wide": True},
+                {"aspect_ratio": 0.5, "width_ratio": 0.6, "wide": True},
                 (4.17, 8.34),
             ),
             (
                 {"columns": "onecolumn", "paper": "a4paper", "fontsize": 11},
-                {"aspect_ratio": 2.0, "width_ratio": 1.0, "wide": False},
+                {"aspect_ratio": 0.5, "width_ratio": 1.0, "wide": False},
                 (5.93, 11.86),
             ),
             (
                 {"columns": "onecolumn", "paper": "letterpaper", "fontsize": 11},
-                {"aspect_ratio": 0.8, "width_ratio": 1.5, "wide": False},
+                {"aspect_ratio": 1.25, "width_ratio": 1.5, "wide": False},
                 (9.24, 7.392),
             ),
         ],

--- a/tests/test_revtex.py
+++ b/tests/test_revtex.py
@@ -91,7 +91,7 @@ class TestFigure:
             ),
             (
                 {"columns": "twocolumn", "fontsize": 11},
-                {"aspect_ratio": 1.4, "width_ratio": 1.0, "wide": False},
+                {"aspect_ratio": 0.71428, "width_ratio": 1.0, "wide": False},
                 (3.42, 4.788),
             ),
             (
@@ -101,17 +101,17 @@ class TestFigure:
             ),
             (
                 {"columns": "twocolumn", "fontsize": 11},
-                {"aspect_ratio": 2.0, "width_ratio": 0.6, "wide": True},
+                {"aspect_ratio": 0.5, "width_ratio": 0.6, "wide": True},
                 (4.248, 8.496),
             ),
             (
                 {"columns": "onecolumn", "fontsize": 11},
-                {"aspect_ratio": 2.0, "width_ratio": 1.0, "wide": False},
+                {"aspect_ratio": 0.5, "width_ratio": 1.0, "wide": False},
                 (3.42, 6.84),
             ),
             (
                 {"columns": "onecolumn", "fontsize": 11},
-                {"aspect_ratio": 0.8, "width_ratio": 1.5, "wide": False},
+                {"aspect_ratio": 1.25, "width_ratio": 1.5, "wide": False},
                 (5.13, 4.104),
             ),
         ],


### PR DESCRIPTION
The documentation of the `figure` function currently states:
```
aspect_ratio (float, optional): the aspect ratio (width/height) of your plot.
                Defaults to the golden ratio.
```

This means that, called $r$ the aspect ratio and $w$, $h$ respectively the width and height of the figure, we expect $w = r\cdot h$. 
However, this is not what happens and `aspect_ratio` behaves as if it was defined as height/width.

The ways to make code and documentation consistent with each other are either changing the documentation to
```
aspect_ratio (float, optional): the aspect ratio (height/width) of your plot.
                Defaults to the golden ratio.
```
or changing the definition of $h$ to $w/r$ (currently is $h=w\cdot r$)


This pull request implements the required changes to follow the second path. In this way, not only the documentation would be consistent with the behaviour of the code, but also the meaning of the parameter would match the common definition of _aspect ratio_ (the ratio between width and height, e.g. 16/9, 4/3 etc).
