### PR TITLE
Make the documentation consistent with the  aspect_ratio parameter definition

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,3 +118,4 @@ A big thanks for contributions goes to:
 [Samuel J. Palmer](https://github.com/sp94), 
 [platipo](https://github.com/platipo), 
 [Lorenzo Fioroni](https://github.com/LorenzoFioroni)
+

--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ If the document class you're targeting is not supported by `rsmf`, you can still
 ## Figures
 The setup routine will return a formatter. This formatter can then be used to create matplotlib figure objects by invoking the method `formatter.figure`. It has three arguments:
 
-* `aspect_ratio` (float, optional): the aspect ratio (width/height) of your plot. Defaults to the golden ratio.
+* `aspect_ratio` (float, optional): the aspect ratio (height/width) of your plot. Defaults to the inverse of the golden ratio.
 * `width_ratio` (float, optional): the width of your plot in multiples of `\columnwidth`. Defaults to 1.0.
 * `wide` (bool, optional): indicates if the figures spans two columns in twocolumn mode, 
                 i.e. if the figure* environment is used, has no effect in onecolumn mode . Defaults to False.
@@ -83,6 +83,8 @@ and included via the multi-column `figure*` environment:
 ```
 
 Note that you should always save your figures in some sort of vectorized format, like `pdf` and that calling `plt.tight_layout()` before saving usually makes your plots nicer.
+
+Moreover, observe that the ``aspect_ratio`` parameter is defined as the height of the plot devided by its width. Even though aspect ratios are more commonly defined as width/height, this choice results in having the width and the height of the figure proportional to ``width_ratio`` and ``aspect_ratio`` respectively. 
 
 It is also possible to create the figure objects by hand, using `formatter.columnwidth` and `formatter.wide_columnwidth`, the `formatter.figure` routine is a convenience wrapper around this.
 

--- a/README.md
+++ b/README.md
@@ -115,5 +115,6 @@ When calling `rsmf.setup`, matplotlib's `rcParams` are adjusted to make the font
 Do you have trouble setting up plots for your favorite document class and it is not supported here? Do not hesitate to make a PR!
 
 A big thanks for contributions goes to:
-[Samuel J. Palmer](https://github.com/sp94)
-[platipo](https://github.com/platipo)
+[Samuel J. Palmer](https://github.com/sp94), 
+[platipo](https://github.com/platipo), 
+[Lorenzo Fioroni](https://github.com/LorenzoFioroni)

--- a/docs/source/howto.rst
+++ b/docs/source/howto.rst
@@ -66,7 +66,7 @@ Figures
 -------
 The setup routine will return a formatter. This formatter can then be used to create matplotlib figure objects by invoking the method ``formatter.figure``. It has three arguments:
 
-* ``aspect_ratio`` (float, optional): the aspect ratio (width/height) of your plot. Defaults to the golden ratio.
+* ``aspect_ratio`` (float, optional): the aspect ratio (height/width) of your plot. Defaults to the inverse of the golden ratio.
 * ``width_ratio`` (float, optional): the width of your plot in multiples of ``\columnwidth``. Defaults to 1.0.
 * ``wide`` (bool, optional): indicates if the figures spans two columns in twocolumn mode, 
                 i.e. if the figure* environment is used, has no effect in onecolumn mode . Defaults to False.
@@ -112,6 +112,8 @@ and included via the multi-column ``figure*`` environment:
     \end{figure*}
 
 Note that you should always save your figures in some sort of vectorized format, like ``pdf`` and that calling ``plt.tight_layout()`` before saving usually makes your plots nicer.
+
+Moreover, observe that the ``aspect_ratio`` parameter is defined as the height of the plot devided by its width. Even though aspect ratios are more commonly defined as width/height, this choice results in having the width and the height of the figure proportional to ``width_ratio`` and ``aspect_ratio`` respectively. 
 
 Custom
 ~~~~~~

--- a/rsmf/__init__.py
+++ b/rsmf/__init__.py
@@ -1,5 +1,6 @@
 """
 Load all methods that are made accessible as the API.
 """
+
 from .custom_formatter import CustomFormatter
 from .setup import setup

--- a/rsmf/abstract_formatter.py
+++ b/rsmf/abstract_formatter.py
@@ -92,7 +92,7 @@ class AbstractFormatter(abc.ABC):
         and the font sizes of the document are well aligned.
 
         Args:
-            aspect_ratio (float, optional): the aspect ratio (width/height) of your plot.
+            aspect_ratio (float, optional): the aspect ratio (height/width) of your plot.
                 Defaults to the golden ratio.
             width_ratio (float, optional): the width of your plot in multiples of \columnwidth.
                 Defaults to 1.0.

--- a/rsmf/abstract_formatter.py
+++ b/rsmf/abstract_formatter.py
@@ -26,7 +26,8 @@ class AbstractFormatter(abc.ABC):
 
         self.set_rcParams()
 
-    @abc.abstractproperty
+    @property
+    @abc.abstractmethod
     def columnwidth(self):
         """columnwidth of the document."""
         raise NotImplementedError("columnwidth is not implemented in subclass.")
@@ -37,7 +38,8 @@ class AbstractFormatter(abc.ABC):
 
         return self.columnwidth
 
-    @abc.abstractproperty
+    @property
+    @abc.abstractmethod
     def wide_columnwidth(self):
         """Wide columnwidth of the document."""
         raise NotImplementedError("wide_columnwidth is not implemented in subclass.")

--- a/rsmf/quantumarticle.py
+++ b/rsmf/quantumarticle.py
@@ -42,9 +42,9 @@ class QuantumarticleFormatter(RevtexLikeFormatter):
 
         plt.rcParams["font.family"] = "sans-serif"
 
-        plt.rcParams[
-            "pgf.preamble"
-        ] = r"\usepackage{lmodern} \usepackage[utf8x]{inputenc} \usepackage[T1]{fontenc}"
+        plt.rcParams["pgf.preamble"] = (
+            r"\usepackage{lmodern} \usepackage[utf8x]{inputenc} \usepackage[T1]{fontenc}"
+        )
 
         plt.rcParams["axes.edgecolor"] = self._colors["quantumgray"]
 

--- a/rsmf/revtex.py
+++ b/rsmf/revtex.py
@@ -12,9 +12,9 @@ class RevtexFormatter(RevtexLikeFormatter):
     and the font sizes of the document are well aligned.
 
     Args:
-        columns (str, optional):  the columns you used to set up your quantumarticle,
+        columns (str, optional):  the columns you used to set up your revtex article,
             either "onecolumn" or "twocolumn". Defaults to "twocolumn".
-        fontsize (int, optional): the fontsize you used to set up your quantumarticle,
+        fontsize (int, optional): the fontsize you used to set up your revtex article,
             either 10, 11 or 12. Defaults to 10.
     """
 

--- a/rsmf/revtexlike.py
+++ b/rsmf/revtexlike.py
@@ -2,7 +2,6 @@
 Base for implementations of document classes alike to revtex.
 """
 
-
 from .abstract_formatter import AbstractFormatter
 from .fontsizes import DEFAULT_FONTSIZES
 

--- a/rsmf/setup.py
+++ b/rsmf/setup.py
@@ -39,6 +39,7 @@ def _extract_preamble(path):
     """
     lines = []
 
+    # pylint: disable=W1514
     with open(path, "r") as file:
         for line in file:
             if "\\begin{document}" in line:
@@ -76,7 +77,7 @@ def setup(arg):
         if result:
             return result
 
-    raise Exception(
+    raise RuntimeError(
         "No formatter was found for the given argument. This means either there is no formatter,"
         + " or, if you gave a file path that it does not exist."
     )


### PR DESCRIPTION
As discussed in #24, the `aspect_ratio` parameter is currently defined as the height of the picture over its width. The documentation, however, describes it as `width/height`. This PR changes the documentation to match the code's behaviour.