### PR TITLE
Fix style selection

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -47,6 +47,9 @@ jobs:
     steps:
       - attach_workspace:
           at: ~/
+      - python/install-packages:
+          args: pytest-mock
+          pkg-manager: pip
       - run:
           command: coverage run -m pytest --junitxml=/tmp/reports/pytest-report.xml .
           name: Run unit tests

--- a/rsmf/abstract_formatter.py
+++ b/rsmf/abstract_formatter.py
@@ -22,7 +22,13 @@ class AbstractFormatter(abc.ABC):
             self._fontsizes = DEFAULT_FONTSIZES_10
 
         mpl.use("pgf")
-        mpl.style.use("seaborn-white")
+
+        styles = mpl.style.available
+
+        if "seaborn-white" in styles:
+            mpl.style.use("seaborn-white")
+        elif "seaborn-v0_8-white" in styles:
+            mpl.style.use("seaborn-v0_8-white")
 
         self.set_rcParams()
 

--- a/rsmf/quantumarticle.py
+++ b/rsmf/quantumarticle.py
@@ -42,9 +42,9 @@ class QuantumarticleFormatter(RevtexLikeFormatter):
 
         plt.rcParams["font.family"] = "sans-serif"
 
-        plt.rcParams[
-            "pgf.preamble"
-        ] = r"\usepackage{lmodern} \usepackage[utf8x]{inputenc} \usepackage[T1]{fontenc}"
+        plt.rcParams["pgf.preamble"] = (
+            r"\usepackage{lmodern} \usepackage[utf8x]{inputenc} \usepackage[T1]{fontenc}"
+        )
 
         plt.rcParams["axes.edgecolor"] = self._colors["quantumgray"]
 

--- a/rsmf/quantumarticle.py
+++ b/rsmf/quantumarticle.py
@@ -42,9 +42,9 @@ class QuantumarticleFormatter(RevtexLikeFormatter):
 
         plt.rcParams["font.family"] = "sans-serif"
 
-        plt.rcParams["pgf.preamble"] = (
-            r"\usepackage{lmodern} \usepackage[utf8x]{inputenc} \usepackage[T1]{fontenc}"
-        )
+        plt.rcParams[
+            "pgf.preamble"
+        ] = r"\usepackage{lmodern} \usepackage[utf8x]{inputenc} \usepackage[T1]{fontenc}"
 
         plt.rcParams["axes.edgecolor"] = self._colors["quantumgray"]
 

--- a/tests/test_abstract_formatter.py
+++ b/tests/test_abstract_formatter.py
@@ -1,7 +1,9 @@
+import matplotlib as mpl
 import matplotlib.pyplot as plt
 import numpy as np
 import pytest
 
+import rsmf.abstract_formatter
 from rsmf.abstract_formatter import AbstractFormatter
 
 
@@ -22,6 +24,44 @@ def abstract_formatter_mock(monkeypatch):
             return fmt
 
         yield formatter
+
+
+class TestInit:
+    """Test that the initialization of the AbstractFormatter class is properly executed."""
+
+    @pytest.mark.parametrize(
+        "styles,target",
+        [
+            (
+                ["test", "seaborn-white", "seaborn"],
+                "seaborn-white",
+            ),
+            (
+                ["test", "seaborn-white", "seaborn", "seaborn-v0_8-white"],
+                "seaborn-white",
+            ),
+            (
+                ["test", "seaborn", "test2", "seaborn-v0_8-white"],
+                "seaborn-v0_8-white",
+            ),
+            (
+                ["test", "seaborn", "test2"],
+                None,
+            ),
+        ],
+    )
+    def test_style_selection(self, monkeypatch, abstract_formatter_mock, mocker, styles, target):
+        mocker.patch("rsmf.abstract_formatter.mpl.style.use")
+
+        with monkeypatch.context() as m:
+            m.setattr(rsmf.abstract_formatter.mpl.style, "available", styles)
+
+            formatter = abstract_formatter_mock()
+
+            if target is None:
+                rsmf.abstract_formatter.mpl.style.use.assert_not_called()
+            else:
+                rsmf.abstract_formatter.mpl.style.use.assert_called_once_with(target)
 
 
 class TestRcParams:


### PR DESCRIPTION
The problem was that the style "seaborn-white" does not exist anymore in newer versions of matplotlib and was replaced with "seaborn-v0_8-white". The new logic will also not break if neither of the styles is available.